### PR TITLE
Update getlist.class.php

### DIFF
--- a/core/components/modxsite/processors/site/web/getlist.class.php
+++ b/core/components/modxsite/processors/site/web/getlist.class.php
@@ -97,9 +97,11 @@ class modSiteWebGetlistProcessor extends modObjectGetListProcessor{
             }
             
             if ($this->flushWhere && isset($c->query['where'])) $c->query['where'] = array();
-            $c->where(array(
-                "{$this->classKey}.id:IN" => $IDs,
-            ));
+            if(count($IDs)) {
+                $c->where(array(
+                    "{$this->classKey}.id:IN" => $IDs,
+                ));
+            }
         }
         else{
             return false;


### PR DESCRIPTION
Если список IDs пуст, то генерируется ошибка. это исправление позволяет ее избежать